### PR TITLE
Win32 spmc task system

### DIFF
--- a/code/plore_platform.h
+++ b/code/plore_platform.h
@@ -128,10 +128,6 @@ typedef PLATFORM_GET_DIRECTORY_ENTRIES(platform_get_directory_entries);
 #define PLATFORM_DIRECTORY_SIZE_TASK_BEGIN(name) void name(platform_taskmaster *Taskmaster, plore_directory_query_state *State)
 typedef PLATFORM_DIRECTORY_SIZE_TASK_BEGIN(platform_directory_size_task_begin);
 
-// @Deprecated
-#define PLATFORM_GET_DIRECTORY_SIZE(name) u64 name(char *DirectoryName)
-typedef PLATFORM_GET_DIRECTORY_SIZE(platform_get_directory_size);
-
 #define PLATFORM_MOVE_FILE(name) b64 name(char *sAbsolutePath, char *dAbsolutePath)
 typedef PLATFORM_MOVE_FILE(platform_move_file);
 

--- a/code/plore_platform.h
+++ b/code/plore_platform.h
@@ -125,7 +125,7 @@ typedef struct directory_entry_result {
 #define PLATFORM_GET_DIRECTORY_ENTRIES(name) directory_entry_result name(char *DirectoryName, plore_file *Buffer, u64 Size)
 typedef PLATFORM_GET_DIRECTORY_ENTRIES(platform_get_directory_entries);
 
-#define PLATFORM_DIRECTORY_SIZE_TASK_BEGIN(name) void name(platform_taskmaster *Taskmaster, plore_directory_query_state *State)
+#define PLATFORM_DIRECTORY_SIZE_TASK_BEGIN(name) void name(platform_taskmaster *Taskmaster, plore_path *Path, plore_directory_query_state *State)
 typedef PLATFORM_DIRECTORY_SIZE_TASK_BEGIN(platform_directory_size_task_begin);
 
 #define PLATFORM_MOVE_FILE(name) b64 name(char *sAbsolutePath, char *dAbsolutePath)
@@ -178,7 +178,6 @@ typedef struct platform_api {
 	platform_directory_size_task_begin   *DirectorySizeTaskBegin;
 	
 	platform_get_directory_entries       *GetDirectoryEntries;
-	platform_get_directory_size          *GetDirectorySize; // @Deprecated
 	platform_get_current_directory       *GetCurrentDirectory;
 	platform_get_current_directory_path  *GetCurrentDirectoryPath;
 	platform_set_current_directory       *SetCurrentDirectory;

--- a/code/win32_plore.c
+++ b/code/win32_plore.c
@@ -325,9 +325,7 @@ PLATFORM_IS_PATH_DIRECTORY(WindowsIsPathDirectory) {
 }
 
 PLATFORM_IS_PATH_TOP_LEVEL(WindowsIsPathTopLevel) {
-	b64 Result = PathIsRoot(Buffer);
-	return(Result);
-	
+	return(PathIsRoot(Buffer));
 }
 
 


### PR DESCRIPTION
This implements a single-producer, multiple-consumer task queue, while deprecating the synchronous `GetDirectorySize` call from the platform layer. 
This call is replaced with a single `DirectorySizeQueryTaskBegin` call in the platform layer, which kicks off a task, and performs additional bookkeeping to ensure only one _directory query task_ can exist at a time - this is not the case for other tasks, but there is good reason to wrap those as well for e.g., caching.
If beginning a new query task while a query is already in progress, this will block in the application layer for a small amount of time, up to `MAX_DIRECTORY_QUERY_SIZE` entries worth of processing in the platform layer, which is typically short.

Multiple tasks in flight have not been tested as of yet, but this is currently stable enough to merge.
